### PR TITLE
fix: warn no-namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export async function wrtnlabs(options: UserOptions, ...args: UserConfigs[]): Pr
   return antfu(_options, {
     rules: {
       "no-unreachable": "error",
+      "ts/no-namespace": "warn",
     },
   }, ...args);
 }


### PR DESCRIPTION
Originally `ts/no-namespace` isn't a warn/error rule.

`namespace` is not recommended anymore, especially after releasing of [ts5.8 erasableSyntaxOnly](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-8.html#the---erasablesyntaxonly-option).
(and I don't like namespace/class because it causes bad performance for tree-shaking)

However, wrtnlabs uses namespace everywhere, so warning is fine for now
