### PR TITLE
feat: introduce feat/redeclare option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export async function wrtnlabs(options: UserOptions, ...args: UserConfigs[]): Pr
   return antfu(_options, {
     rules: {
       "no-unreachable": "error",
+      "no-redeclare": "warn", // for type hierarchy structure(ex: ChatCompletion.Choice)
     },
   }, ...args);
 }


### PR DESCRIPTION
Redeclare are often used to create hierarchies between types.

If we don't use namespaces, we won't have this case.
Unfortunately, we have a lot of namespaces.

```ts
export type IAgenticaSelectBenchmarkEvent<Model extends ILlmSchema.Model> =
  | IAgenticaSelectBenchmarkEvent.ISuccess<Model>
  | IAgenticaSelectBenchmarkEvent.IFailure<Model>
  | IAgenticaSelectBenchmarkEvent.IError<Model>;
export namespace IAgenticaSelectBenchmarkEvent {
    // ....
}
```

---

This pull request includes a small change to the `src/index.ts` file. The change adds a new rule to the `wrtnlabs` function to warn against redeclaration, which is useful for maintaining the type hierarchy structure, such as `ChatCompletion.Choice`.

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R44): Added the `"no-redeclare": "warn"` rule to the `wrtnlabs` function to prevent redeclaration issues.