### PR TITLE
fix: handle missing tsconfig.json gracefully

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,9 +38,9 @@ export async function wrtnlabs(options: UserOptions, ...args: UserConfigs[]): Pr
     },
   } as const satisfies UserOptions);
 
-	if (typeof _options.typescript !== 'boolean' && _options?.typescript?.tsconfigPath == null) {
-		console.warn('tsconfig.json is not found. we cannot use type-aware rules.');
-	}
+  if (typeof _options.typescript !== "boolean" && _options?.typescript?.tsconfigPath == null) {
+    console.warn("tsconfig.json is not found. we cannot use type-aware rules.");
+  }
 
   return antfu(_options, {
     rules: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ type UserConfigs = Parameters<typeof antfu>[1];
 type ESLintConfig = ReturnType<typeof antfu>;
 
 // eslint-disable-next-line antfu/no-top-level-await
-const tsconfigPath = await resolveTSConfig();
+const tsconfigPath = await resolveTSConfig().then(path => path).catch(() => undefined);
 
 export async function wrtnlabs(options: UserOptions, ...args: UserConfigs[]): Promise<ESLintConfig> {
   const _options = defu(options, {
@@ -37,6 +37,10 @@ export async function wrtnlabs(options: UserOptions, ...args: UserConfigs[]): Pr
       },
     },
   } as const satisfies UserOptions);
+
+	if (typeof _options.typescript !== 'boolean' && _options?.typescript?.tsconfigPath == null) {
+		console.warn('tsconfig.json is not found. we cannot use type-aware rules.');
+	}
 
   return antfu(_options, {
     rules: {


### PR DESCRIPTION
Allow the config to work when no tsconfig.json is present by catching
errors from resolveTSConfig and adding a warning message when
type-aware rules can't be applied due to missing tsconfig.