### PR TITLE
feat: publish-dry-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: none
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
@@ -17,9 +15,7 @@ jobs:
 
   publish-dry-run:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: none
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,14 @@ jobs:
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
+
+  publish-dry-run:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: none
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm dlx pkg-pr-new publish --pnpm

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "lint": "eslint --cache .",
     "format": "nr lint --fix",
     "inspector": "nlx @eslint/config-inspector",
-    "prepack": "nr lint && nr build && nlx publint",
-    "release": "nr prepack && nlx bumpp"
+    "prepack": "nr build",
+    "release": "nr lint && nr prepack && nr publint && nlx bumpp"
   },
   "dependencies": {
     "@antfu/eslint-config": "^4.10.2",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "lint": "eslint --cache .",
     "format": "nr lint --fix",
     "inspector": "nlx @eslint/config-inspector",
-    "prepublishOnly": "nr lint && nr build && nlx publint",
-    "release": "nr lint && nr build && nlx publint && nlx bumpp"
+    "prepack": "nr lint && nr build && nlx publint",
+    "release": "nr prepack && nlx bumpp"
   },
   "dependencies": {
     "@antfu/eslint-config": "^4.10.2",


### PR DESCRIPTION
This pull request introduces a new job to the CI workflow and updates the `package.json` scripts to streamline the build and release process. The most important changes are as follows:

CI Workflow Enhancements:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR17-R28): Added a new `publish-dry-run` job to the CI workflow to perform a dry run of the publish process. This job includes steps for checking out the repository, setting up `pnpm`, installing dependencies, and running a dry run of the publish command.

Build and Release Script Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L32-R33): Replaced the `prepublishOnly` script with `prepack` to ensure linting, building, and publishing lint checks are performed before packaging. Updated the `release` script to call `prepack` instead of duplicating the steps.