### PR TITLE
feat: add import order rules for #6

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,13 @@ export async function wrtnlabs(options: UserOptions, ...args: UserConfigs[]): Pr
   return antfu(_options, {
     rules: {
       "no-unreachable": "error",
+      "import/order": ["error", {
+        "newlines-between": "always",
+        "alphabetize": {
+          order: "asc",
+          caseInsensitive: true,
+        },
+      }],
     },
   }, ...args);
 }


### PR DESCRIPTION
add `import/order` rule  
I empty group property for user can eazy override(actually our team don't have specificated import order rule lol)

---

This pull request includes a change to the `src/index.ts` file to improve code quality by enforcing import order rules.

Code quality improvement:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R50-R56): Added a new rule to enforce import order with newlines between groups and alphabetization in a case-insensitive manner.