### PR TITLE
fix: ignore no-redeclare, no-namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,8 @@ export async function wrtnlabs(options: UserOptions, ...args: UserConfigs[]): Pr
       tsconfigPath,
       overrides: {
         // ref: https://github.com/wrtnlabs/eslint-config/issues/11
-
-        // "ts/no-redeclare": "warn", // for type hierarchy structure(ex: ChatCompletion.Choice)
-        // "ts/no-namespace": "warn", // namespace is not recommended, but we have a lot of namespaces, so now we just warn
+        "ts/no-redeclare": "off", // for type hierarchy structure(ex: ChatCompletion.Choice)
+        "ts/no-namespace": "off", // namespace is not recommended, but we have a lot of namespaces, so now we just warn
       },
       overridesTypeAware: {
         "ts/strict-boolean-expressions": ["error", { allowNullableBoolean: false, allowNullableObject: false, allowString: false }], // compare with `null` and `undefined` is not allowed

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,10 @@ export async function wrtnlabs(options: UserOptions, ...args: UserConfigs[]): Pr
     typescript: {
       tsconfigPath,
       overrides: {
-        "ts/no-redeclare": "warn", // for type hierarchy structure(ex: ChatCompletion.Choice)
-        "ts/no-namespace": "warn", // namespace is not recommended, but we have a lot of namespaces, so now we just warn
+        // ref: https://github.com/wrtnlabs/eslint-config/issues/11
+
+        // "ts/no-redeclare": "warn", // for type hierarchy structure(ex: ChatCompletion.Choice)
+        // "ts/no-namespace": "warn", // namespace is not recommended, but we have a lot of namespaces, so now we just warn
       },
       overridesTypeAware: {
         "ts/strict-boolean-expressions": ["error", { allowNullableBoolean: false, allowNullableObject: false, allowString: false }], // compare with `null` and `undefined` is not allowed


### PR DESCRIPTION
This pull request includes changes to the TypeScript configuration in the `wrtnlabs` function within the `src/index.ts` file. The most important change involves commenting out two ESLint rules and adding a reference to an issue in the `wrtnlabs` repository.

Configuration changes:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L17-R20): Commented out the `ts/no-redeclare` and `ts/no-namespace` ESLint rules and added a reference to issue #11 in the `wrtnlabs` repository.