### PR TITLE
fix(rule): remove import/order and add sort-imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,13 +52,12 @@ export async function wrtnlabs(options: UserOptions, ...args: UserConfigs[]): Pr
     {
       rules: {
         "no-unreachable": "error",
-        // sort-imports and import/order have conflicting rules. Therefore, we disable sort-imports.
-        "perfectionist/sort-imports": "off",
-        "import/order": ["error", {
-          "groups": ["builtin", "external", "internal", "index", "type"],
-          "newlines-between": "always",
-          "sortTypesGroup": false,
+        // sort-imports and import/order have conflicting rules. Therefore, we disable import/order.
+        "perfectionist/sort-imports": ["error", {
+          order: "asc",
+          groups: ["builtin", "type", "external", "internal-type", "internal", "parent-type", "parent", "sibling-type", "sibling", "index-type", "index"],
         }],
+        "import/order": "off",
       },
     },
     ...tailwindRules,

--- a/src/next.ts
+++ b/src/next.ts
@@ -1,8 +1,8 @@
 import { defu } from "defu";
 
-import { wrtnlabs } from "./index";
-
 import type { ESLintConfig, UserOptions } from "./options";
+
+import { wrtnlabs } from "./index";
 
 export const wrtnlabsNext = (async (options, ...args): Promise<ESLintConfig> => {
   const _options = defu(

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,5 @@
 import type antfu from "@antfu/eslint-config";
+
 import type { TailwindCssOptions } from "./rules";
 
 export type UserOptions = Parameters<typeof antfu>[0] & {

--- a/src/rules/next.ts
+++ b/src/rules/next.ts
@@ -1,8 +1,8 @@
 /* eslint-disable ts/no-unsafe-member-access */
 /* eslint-disable ts/no-unsafe-assignment */
-import { ensurePackages, interopDefault } from "@antfu/eslint-config";
-
 import type { TypedFlatConfigItem } from "@antfu/eslint-config";
+
+import { ensurePackages, interopDefault } from "@antfu/eslint-config";
 
 export async function next(enabled = false): Promise<TypedFlatConfigItem[]> {
   if (!enabled) {

--- a/src/rules/tailwindcss.ts
+++ b/src/rules/tailwindcss.ts
@@ -1,6 +1,6 @@
-import { ensurePackages, interopDefault } from "@antfu/eslint-config";
-
 import type { TypedFlatConfigItem } from "@antfu/eslint-config";
+
+import { ensurePackages, interopDefault } from "@antfu/eslint-config";
 
 export interface TailwindCssOptions {
 /**


### PR DESCRIPTION
current change is the example!
![image](https://github.com/user-attachments/assets/ded90f59-fad2-488a-8021-122511cae47f)
`groups: ["builtin", "type", "external", "internal-type", "internal", "parent-type", "parent", "sibling-type", "sibling", "index-type", "index"]`

we need conversation about it.

This is because the differences in individual preferences are different.

First of all, the path is divided between all types, and each parent, sabling, external, and built-in is separated!

Thank you for reading!

---

This pull request includes several changes to improve the ESLint configuration and organize import statements. The most important changes include modifying the ESLint rules for sorting imports and organizing imports in various files.

Changes to ESLint rules:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L55-R60): Updated the ESLint rules to enable `perfectionist/sort-imports` with specific order settings and disable `import/order` to resolve conflicting rules.

Reorganization of imports:

* [`src/next.ts`](diffhunk://#diff-a23e0ceb07441d86d85794fc6df8d0abe512f64ed0753fdb30fa1dba0dfc89c5L3-R6): Moved the import statement for `wrtnlabs` to group it with other imports for better organization.
* [`src/options.ts`](diffhunk://#diff-2123f97b7bf9480a61717c843425e483e8d97819592e8c04e4e149eb65b451e8R2): Added a blank line between import statements to improve readability.
* [`src/rules/next.ts`](diffhunk://#diff-0a85e24fd60b733f6b3ed578d9b927281c5672c6a6ec7cc5db9925cf0f9a5f95L3-R6): Reorganized import statements to group them together for better clarity.
* [`src/rules/tailwindcss.ts`](diffhunk://#diff-03e2fefba42ab33a269922ed66de8b720dc8adf94615d462b6a4a13cf9675ee4L1-R4): Reorganized import statements to group them together for better clarity.